### PR TITLE
Bunch of stuff

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenNetRoom overlay/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenNetRoom overlay/default.lua
@@ -38,46 +38,6 @@ t[#t+1] = LoadFont("Common Large")..{
 t[#t+1] = LoadActor("../_cursor");
 t[#t+1] = LoadActor("currenttime");
 t[#t+1] = LoadActor("../_halppls");
-
-
-t[#t+1] = LoadFont("Common Normal") .. {
-	InitCommand=cmd(xy,SCREEN_WIDTH/3,SCREEN_TOP+15;zoom,0.35;diffuse,getMainColor('positive');maxwidth,SCREEN_WIDTH),
-	BeginCommand=cmd(queuecommand,"Set"),
-	SetCommand=function(self)
-			local str = ""
-			local top = SCREENMAN:GetTopScreen()
-			if top:GetUserQty() > 5 then
-				for i=1,5 do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			
-			else
-				for i=1,top:GetUserQty() do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			end
-			self:settext(str)
-	end,
-	PlayerJoinedMessageCommand=cmd(queuecommand,"Set"),
-	PlayerUnjoinedMessageCommand=cmd(queuecommand,"Set"),
-	UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
-}
-t[#t+1] = LoadFont("Common Normal") .. {
-	InitCommand=cmd(xy,SCREEN_WIDTH/3,SCREEN_TOP+25;zoom,0.35;diffuse,getMainColor('positive');maxwidth,SCREEN_WIDTH),
-	BeginCommand=cmd(queuecommand,"Set"),
-	SetCommand=function(self)
-			local str = ""
-			local top = SCREENMAN:GetTopScreen()
-			if top:GetUserQty() > 5 then
-				for i=6,top:GetUserQty() do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			end
-			self:settext(str)
-	end,
-	PlayerJoinedMessageCommand=cmd(queuecommand,"Set"),
-	PlayerUnjoinedMessageCommand=cmd(queuecommand,"Set"),
-	UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
-}
+t[#t+1] = LoadActor("../_userlist");
 
 return t

--- a/Themes/Til Death/BGAnimations/ScreenNetSelectBase overlay/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenNetSelectBase overlay/default.lua
@@ -41,45 +41,6 @@ t[#t+1] = LoadFont("Common Large")..{InitCommand=cmd(xy,5,32;halign,0;valign,1;z
 t[#t+1] = LoadActor("../_cursor")
 t[#t+1] = LoadActor("../_halppls")
 --t[#t+1] = LoadActor("wifesearchbar")
-
-t[#t+1] = LoadFont("Common Normal") .. {
-	InitCommand=cmd(xy,SCREEN_WIDTH/3,SCREEN_TOP+15;zoom,0.35;diffuse,getMainColor('positive');maxwidth,SCREEN_WIDTH),
-	BeginCommand=cmd(queuecommand,"Set"),
-	SetCommand=function(self)
-			local str = ""
-			local top = SCREENMAN:GetTopScreen()
-			if top:GetUserQty() > 5 then
-				for i=1,5 do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			
-			else
-				for i=1,top:GetUserQty() do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			end
-			self:settext(str)
-	end,
-	PlayerJoinedMessageCommand=cmd(queuecommand,"Set"),
-	PlayerUnjoinedMessageCommand=cmd(queuecommand,"Set"),
-	UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
-}
-t[#t+1] = LoadFont("Common Normal") .. {
-	InitCommand=cmd(xy,SCREEN_WIDTH/3,SCREEN_TOP+25;zoom,0.35;diffuse,getMainColor('positive');maxwidth,SCREEN_WIDTH),
-	BeginCommand=cmd(queuecommand,"Set"),
-	SetCommand=function(self)
-			local str = ""
-			local top = SCREENMAN:GetTopScreen()
-			if top:GetUserQty() > 5 then
-				for i=6,top:GetUserQty() do
-					str = str .. "      " .. (top:GetUser(i))
-				end
-			end
-			self:settext(str)
-	end,
-	PlayerJoinedMessageCommand=cmd(queuecommand,"Set"),
-	PlayerUnjoinedMessageCommand=cmd(queuecommand,"Set"),
-	UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
-}
+t[#t+1] = LoadActor("../_userlist")
 
 return t

--- a/Themes/Til Death/BGAnimations/ScreenNetSelectMusic decorations/profile.lua
+++ b/Themes/Til Death/BGAnimations/ScreenNetSelectMusic decorations/profile.lua
@@ -47,7 +47,12 @@ t[#t+1] = Def.Quad{InitCommand=cmd(xy,frameX,frameY;zoomto,frameWidth,offsetY;ha
 t[#t+1] = LoadFont("Common Normal")..{InitCommand=cmd(xy,frameX+5,frameY+offsetY-9;zoom,0.6;halign,0;diffuse,getMainColor('positive');settext,"Profile Info (WIP)")}
 
 -- The input callback for mouse clicks already exists within the tabmanager and redefining it within the local scope does nothing but create confusion - mina
-local r = Def.ActorFrame{}
+local r = Def.ActorFrame{
+	-- Cache the ranking
+	BeginCommand=function(self)
+		profile:GetTopSSRValue(250, rankingSkillset)
+	end,
+}
 	
 local function rankingLabel(i)
 	local ths -- the top highscore object - mina

--- a/Themes/Til Death/BGAnimations/_userlist.lua
+++ b/Themes/Til Death/BGAnimations/_userlist.lua
@@ -1,0 +1,85 @@
+local usersZoom = 0.35
+local usersWidth = 50
+local usersWidthSmall = 25
+local usersWidthZoom = 50 * (1/usersZoom)
+local usersWidthSmallZoom = 25 * (1/usersZoom)
+local usersRowSize = 4
+local usersX = SCREEN_WIDTH/4
+local usersY = SCREEN_TOP+15
+local usersHeight = 10
+
+local top = SCREENMAN:GetTopScreen()
+local qty = 0
+local posit = getMainColor('positive')
+local negat = getMainColor('negative')
+local enable = getMainColor('enabled')
+local r = Def.ActorFrame{
+	BeginCommand=cmd(queuecommand,"Set"),
+	InitCommand=cmd(queuecommand,"Set"),
+	SetCommand=function(self)
+		top = SCREENMAN:GetTopScreen()
+	end,
+	UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
+}
+
+
+local function userLabel(i)
+	local x = 0
+	local y = 0
+	if i <= usersRowSize then
+		x = (usersX) + (i*usersWidth)
+		y = usersY+usersHeight
+	elseif i <= usersRowSize*2 then
+		x = (usersX) + ((i-usersRowSize)*usersWidth)
+		y = usersY
+	elseif i <= usersRowSize*3 then
+		x = (usersX) + ((i-usersRowSize*2)*usersWidth) + usersWidthSmall
+		y = usersY+usersHeight
+	elseif i <= usersRowSize*4 then
+		x = (usersX) + ((i-usersRowSize*3)*usersWidth) + usersWidthSmall
+		y = usersY
+	elseif i <= usersRowSize*5 then
+		x = (usersX) + (usersRowSize*usersWidth) + usersWidthSmall * (i-usersRowSize*4)
+		y = usersY
+	else
+		x = (usersX) + (usersRowSize*usersWidth) + usersWidthSmall * (i-usersRowSize*5)
+		y = usersY+usersHeight
+	end
+	local aux = LoadFont("Common Normal") .. {
+		Name = i,
+		BeginCommand=cmd(xy,x,y;zoom,usersZoom;diffuse,posit;queuecommand,"Set"),
+		SetCommand=function(self)
+			local num = self:GetName()+0
+			qty = top:GetUserQty()
+			if num <= qty then
+				local str = ""
+				str = str ..  top:GetUser(num)
+				self:settext(str)
+				if top:GetUserState(num) == 2 or top:GetUserState(num) == 1 then
+					self:diffuse(posit)
+				elseif top:GetUserState(num) == 4 then
+					self:diffuse(negat)
+				else
+					self:diffuse(enable)
+				end
+			else
+				self:settext("")
+			end
+			if qty < 9 then
+				self:maxwidth(usersWidthZoom )
+			else
+				self:maxwidth(usersWidthSmallZoom)
+			end
+		end,
+		PlayerJoinedMessageCommand=cmd(queuecommand,"Set"),
+		PlayerUnjoinedMessageCommand=cmd(queuecommand,"Set"),
+		UsersUpdateMessageCommand=cmd(queuecommand,"Set"),
+	}
+	return aux
+end
+
+for i=1,32 do
+	r[#r+1] = userLabel(i)
+end
+
+return r

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2423,8 +2423,11 @@ void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) 
 					if (topSSRs[i] < ssr) {
 						CalcAllTopSSRs(qty);
 					}
+					else
+						return;
 				}
 			}
+			CalcAllTopSSRs(qty);
 			return;
 			//
 

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2256,7 +2256,7 @@ bool Profile::CalcTopSSRs(unsigned int qty, int skillset) {
 
 	vector<float> topSSRs; //Auxiliary vector to sort faster
 
-	//Pointers to the skillset's vectors
+						   //Pointers to the skillset's vectors
 	vector<HighScore*> *topSSRHighScoresPtr = &topSSRHighScores[skillset];
 	vector<StepsID> *topSSRStepIdsPtr = &topSSRStepIds[skillset];
 	vector<SongID> *topSSRSongIdsPtr = &topSSRSongIds[skillset];
@@ -2285,10 +2285,17 @@ bool Profile::CalcTopSSRs(unsigned int qty, int skillset) {
 		(*topSSRHighScoresPtr).emplace_back(emptyHighScorePtr);
 	}
 
+	struct info {
+		float ssr;
+		unsigned int pos;
+	};
+	info temp[40];
+	bool replaced = false;
+
 	//Build the top
 	FOREACHM(SongID, HighScoresForASong, m_SongHighScores, i) {
 		const SongID& id = i->first;
-		
+
 		if (!id.IsValid())
 			continue;
 
@@ -2302,16 +2309,39 @@ bool Profile::CalcTopSSRs(unsigned int qty, int skillset) {
 			Steps* psteps = stepsid.ToSteps(id.ToSong(), true);
 			if (!psteps)
 				continue;
+			for (int i = 0;i < 40;i++) {
+				temp[i].ssr = 0;
+				temp[i].pos = 0;
+			}
+
 			for (size_t i = 0; i < hsv.size(); i++) {
 				float ssr = hsv[i].GetSkillsetSSR(static_cast<Skillset>(skillset));
+				int rate = static_cast<int>(hsv[i].GetMusicRate() * 20);
+
+				if ((temp[rate - 1]).ssr >= ssr)
+					continue;
 				//Compare with the smallest value(last one) to see if we need to change the values
 				if (topSSRs[qty - 1] < ssr) {
+
+					if ((temp[rate - 1]).ssr != 0)
+						replaced = true;
+
+					if (replaced) {
+						(*topSSRStepIdsPtr).erase((*topSSRStepIdsPtr).begin() + temp[rate - 1].pos);
+						topSSRs.erase(topSSRs.begin() + temp[rate - 1].pos);
+						(*topSSRSongIdsPtr).erase((*topSSRSongIdsPtr).begin() + temp[rate - 1].pos);
+						(*topSSRHighScoresPtr).erase((*topSSRHighScoresPtr).begin() + temp[rate - 1].pos);
+						qty--;
+					}
+
 
 					//Find the position of the inmediate smaller value
 					for (poscounter = qty - 1; topSSRs[poscounter - 1] < ssr && poscounter != 0;) {
 						poscounter--;
 					}
-					counter++;
+
+					temp[rate - 1].pos = poscounter;
+					temp[rate - 1].ssr = ssr;
 
 					//insert in the proper place
 					(*topSSRStepIdsPtr).insert((*topSSRStepIdsPtr).begin() + poscounter, stepsid);
@@ -2319,11 +2349,17 @@ bool Profile::CalcTopSSRs(unsigned int qty, int skillset) {
 					(*topSSRSongIdsPtr).insert((*topSSRSongIdsPtr).begin() + poscounter, id);
 					(*topSSRHighScoresPtr).insert((*topSSRHighScoresPtr).begin() + poscounter, &(hsv[i]));
 
+
 					//erase last element to keep the same amount of elements(qty)
-					topSSRs.pop_back();
-					(*topSSRStepIdsPtr).pop_back();
-					(*topSSRSongIdsPtr).pop_back();
-					(*topSSRHighScoresPtr).pop_back();
+					if (!replaced) {
+						counter++;
+						topSSRs.pop_back();
+						(*topSSRStepIdsPtr).pop_back();
+						(*topSSRSongIdsPtr).pop_back();
+						(*topSSRHighScoresPtr).pop_back();
+					}
+					else
+						qty++;
 				}
 			}
 		}
@@ -2335,7 +2371,8 @@ bool Profile::CalcTopSSRs(unsigned int qty, int skillset) {
 	return false;
 }
 
-
+//Todo: Make this not recalc everything -Nick12
+//What's below the return currently crashes
 void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) {
 	for (int skillset = 0; skillset < NUM_Skillset; skillset++) {//undefined skillset
 		if (skillset < 0 || skillset >= NUM_Skillset)
@@ -2354,7 +2391,7 @@ void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) 
 
 		vector<float> topSSRs; //Auxiliary vector to sort faster
 
-							   //Pointers to the skillset's vectors
+		//Pointers to the skillset's vectors
 		vector<HighScore*> *topSSRHighScoresPtr = &topSSRHighScores[skillset];
 		vector<StepsID> *topSSRStepIdsPtr = &topSSRStepIds[skillset];
 		vector<SongID> *topSSRSongIdsPtr = &topSSRSongIds[skillset];
@@ -2373,8 +2410,48 @@ void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) 
 		}
 
 		float ssr = hs->GetSkillsetSSR(static_cast<Skillset>(skillset));
+
 		//Compare with the smallest value(last one) to see if we need to change the values
 		if (topSSRs[qty - 1] < ssr) {
+
+			//This isnt finished so we just recalc it all for the moment when we find it needs to
+			//
+			for (unsigned int i = 0; i < qty; i++) {
+				if ((*topSSRSongIdsPtr)[i] == songid && (*topSSRStepIdsPtr)[i] == stepsid &&
+				(*topSSRHighScoresPtr)[i]->GetMusicRate() == hs->GetMusicRate() &&
+				(*topSSRHighScoresPtr)[i] != NULL) {
+					if (topSSRs[i] < ssr) {
+						CalcAllTopSSRs(qty);
+					}
+				}
+			}
+			return;
+			//
+
+			//Check for duplicates
+			bool replace = false;
+			bool matches = false;
+			for (unsigned int i = 0; i < qty; i++) {
+				if ((*topSSRSongIdsPtr)[i] == songid && (*topSSRStepIdsPtr)[i] == stepsid &&
+					(*topSSRHighScoresPtr)[i]->GetMusicRate() == hs->GetMusicRate() &&
+					(*topSSRHighScoresPtr)[i] != NULL) {
+					matches = true;
+					if (topSSRs[i] < ssr) {
+						(*topSSRStepIdsPtr).erase((*topSSRStepIdsPtr).begin() + i);
+						topSSRs.erase(topSSRs.begin() + i);
+						(*topSSRSongIdsPtr).erase((*topSSRSongIdsPtr).begin() + i);
+						(*topSSRHighScoresPtr).erase((*topSSRHighScoresPtr).begin() + i);
+						qty--;
+						replace = true;
+					}
+					else
+						break;
+				}
+			}
+
+			//If there is a match but we dont replace just skip the whole thing
+			if (matches && !replace)
+				continue;
 
 			//Find the position of the inmediate smaller value
 			for (poscounter = qty - 1; topSSRs[poscounter - 1] < ssr && poscounter != 0;) {
@@ -2388,10 +2465,12 @@ void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) 
 			(*topSSRHighScoresPtr).insert((*topSSRHighScoresPtr).begin() + poscounter, hs);
 
 			//erase last element to keep the same amount of elements(qty)
-			topSSRs.pop_back();
-			(*topSSRStepIdsPtr).pop_back();
-			(*topSSRSongIdsPtr).pop_back();
-			(*topSSRHighScoresPtr).pop_back();
+			if (!replace) {
+				topSSRs.pop_back();
+				(*topSSRStepIdsPtr).pop_back();
+				(*topSSRSongIdsPtr).pop_back();
+				(*topSSRHighScoresPtr).pop_back();
+			}
 		}
 
 	}

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -2420,10 +2420,7 @@ void Profile::TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid) 
 				if ((*topSSRSongIdsPtr)[i] == songid && (*topSSRStepIdsPtr)[i] == stepsid &&
 				(*topSSRHighScoresPtr)[i]->GetMusicRate() == hs->GetMusicRate() &&
 				(*topSSRHighScoresPtr)[i] != NULL) {
-					if (topSSRs[i] < ssr) {
-						CalcAllTopSSRs(qty);
-					}
-					else
+					if (topSSRs[i] >= ssr)
 						return;
 				}
 			}

--- a/src/Profile.h
+++ b/src/Profile.h
@@ -449,6 +449,7 @@ public:
 	//TopSSRs
 	bool CalcTopSSRs(unsigned int qty, int skillset);
 	bool CalcAllTopSSRs(unsigned int qty);
+	void TopSSRsAddNewScore(HighScore *hs, StepsID stepsid, SongID songid);
 	float GetTopSSRMSD(unsigned int rank, int skillset);
 	HighScore* GetTopSSRHighScore(unsigned int rank, int skillset);
 	SongID GetTopSSRSongID(unsigned int rank, int skillset);

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -794,7 +794,12 @@ bool ScreenEvaluation::MenuStart( const InputEventPlus &input )
 void ScreenEvaluation::HandleMenuStart()
 {
 	Profile *prof = PROFILEMAN->GetProfile( static_cast<PlayerNumber>(0) );
-	prof->CalcAllTopSSRs( (prof->topSSRStepIds[0]).size() );
+	HighScore * hs = &(m_pStageStats->m_player[0].m_HighScore);
+	StepsID stepsid;
+	stepsid.FromSteps(GAMESTATE->m_pCurSteps[PLAYER_1]);
+	SongID songid;
+	songid.FromSong(GAMESTATE->m_pCurSong);
+	prof->AddNewScore(hs, stepsid, songid);
 	StartTransitioningScreen( SM_GoToNextScreen );
 }
 

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -793,6 +793,8 @@ bool ScreenEvaluation::MenuStart( const InputEventPlus &input )
 
 void ScreenEvaluation::HandleMenuStart()
 {
+	Profile *prof = PROFILEMAN->GetProfile( static_cast<PlayerNumber>(0) );
+	prof->CalcAllTopSSRs( (prof->topSSRStepIds[0]).size() );
 	StartTransitioningScreen( SM_GoToNextScreen );
 }
 

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -799,7 +799,7 @@ void ScreenEvaluation::HandleMenuStart()
 	stepsid.FromSteps(GAMESTATE->m_pCurSteps[PLAYER_1]);
 	SongID songid;
 	songid.FromSong(GAMESTATE->m_pCurSong);
-	prof->AddNewScore(hs, stepsid, songid);
+	prof->TopSSRsAddNewScore(hs, stepsid, songid);
 	StartTransitioningScreen( SM_GoToNextScreen );
 }
 

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -494,6 +494,14 @@ class LunaScreenNetSelectBase : public Luna<ScreenNetSelectBase>
 			lua_pushstring(L, "");
 		return 1;
 	}
+	static int GetUserState(T* p, lua_State *L)
+	{
+		if (IArg(1) <= p->ToUsers()->size() && IArg(1) >= 1)
+			lua_pushnumber(L, NSMAN->m_PlayerStatus[NSMAN->m_ActivePlayer[IArg(1) - 1]] );
+		else
+			lua_pushnumber(L, 0);
+		return 1;
+	}
 public:
 	LunaScreenNetSelectBase()
 	{
@@ -502,6 +510,7 @@ public:
 		ADD_METHOD(ChatboxInput);
 		ADD_METHOD(ChatboxVisible);
 		ADD_METHOD(GetUserQty);
+		ADD_METHOD(GetUserState);
 	}
 };
 

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -228,7 +228,8 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 				StartSelectedSong();
 				goto done;
 			}
-		}
+		} else
+			m_MusicWheel.ReloadSongList(false, "");
 
 		m_MusicWheel.ReloadSongList(false, "");
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -211,25 +211,37 @@ void ScreenNetSelectMusic::HandleScreenMessage( const ScreenMessage SM )
 		Song* CurSong = m_MusicWheel.GetSelectedSong();
 
 		if(CurSong != NULL )
-
 			if( ( !CurSong->GetTranslitArtist().CompareNoCase( NSMAN->m_sArtist ) ) &&
-					( !CurSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
-					( !CurSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
-		{
-			switch ( NSMAN->m_iSelectMode )
+			( !CurSong->GetTranslitMainTitle().CompareNoCase( NSMAN->m_sMainTitle ) ) &&
+			( !CurSong->GetTranslitSubTitle().CompareNoCase( NSMAN->m_sSubTitle ) ) )
 			{
-			case 0:
-			case 1:
-				NSMAN->m_iSelectMode = 0;
-				NSMAN->SelectUserSong();
-				break;
-			case 2:	// Proper starting of song
-			case 3:	// Blind starting of song
-				StartSelectedSong();
-				goto done;
+				switch ( NSMAN->m_iSelectMode )
+				{
+				case 0:
+				case 1:
+					NSMAN->m_iSelectMode = 0;
+					NSMAN->SelectUserSong();
+					break;
+				case 2:	// Proper starting of song
+				case 3:	// Blind starting of song
+					StartSelectedSong();
+					goto done;
+				}
 			}
-		} else
+			else {
+				FOREACH_ENUM(Skillset, i) {
+					GAMESTATE->SSFilterLowerBounds[i] = 0;
+					GAMESTATE->SSFilterUpperBounds[i] = 0;
+				}
+				m_MusicWheel.ReloadSongList(false, "");
+			}
+		else {
+			FOREACH_ENUM(Skillset, i) {
+				GAMESTATE->SSFilterLowerBounds[i] = 0;
+				GAMESTATE->SSFilterUpperBounds[i] = 0;
+			}
 			m_MusicWheel.ReloadSongList(false, "");
+		}
 
 		m_MusicWheel.ReloadSongList(false, "");
 		vector <Song *> AllSongs = SONGMAN->GetAllSongs();


### PR DESCRIPTION
--Fix a crash that happened when filters were being used and someone started a song not currently in the wheel(Filters get reset if someone picks a song and the user isn't standing on it)
--Make the SSR ranking check for duplicates(song+steps+rate(0.05 precision for rate)))
--Make the ranking reload(complete recalc) on evaluation screen
--Improve said reloading since it's just one song(just insert it if needs be)
--Go back to initial ranking reloading since i added duplicate checking(I tried to make it work but i get crashes so I'll see about improving this later)
--Make the ranking calculate the first 250 values when you enter screennetselectmusic
--Fix a bug with searching online that deselected the song after you picked it while searching and you had to go back to it manually to start it
--Improve the userlist control from lua(Added a function to get the player's state) and implement it in Til Death(enabled color for players in options, negative for ingame and positive for the rest)
