### PR TITLE
Change the appearance of Til Death/ScreenSelectMusic

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
@@ -7,6 +7,7 @@ local rateIndex = 1
 local scoreIndex = 1
 local score
 local pn = GAMESTATE:GetEnabledPlayers()[1]
+local skillsetsSSR = {"Overall", "Stream", "Jumpstream", "Handstream", "Stamina", "JackSpeed", "JackStamina", "Technical"}
 
 local defaultRateText = ""
 if themeConfig:get_data().global.RateSort then
@@ -183,74 +184,44 @@ t[#t+1] = LoadFont("Common Normal")..{
 	-- ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
 -- }
 
--- SSR displays
-t[#t+1] = LoadFont("Common Normal")..{
-	Name="Score",
-	InitCommand=cmd(xy,frameX+offsetX+155,frameY+offsetY+28;zoom,0.5;halign,0),
-	SetCommand=function(self)
-		if score ~= nil then
-			if score:GetWifeScore() == 0 then 
-				self:settext("")
-			else
-				self:settextf("%5.2f", score:GetSkillsetSSR(2))
-			end
-		else
-			self:settext("")
-		end
-	end,
-	ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
-}
+-- SSR displays but better
 
-t[#t+1] = LoadFont("Common Normal")..{
-	Name="Score",
-	InitCommand=cmd(xy,frameX+offsetX+155,frameY+offsetY+38;zoom,0.5;halign,0),
-	SetCommand=function(self)
-		if score ~= nil then
-			if score:GetWifeScore() == 0 then 
-				self:settext("")
+for i=1,#skillsetsSSR do
+	t[#t+1] = LoadFont("Common Normal") .. {
+		Name=skillsetsSSR[i].."Score",
+		InitCommand=cmd(xy,frameX+frameWidth*0.7,frameY+offsetY+125+18*(i-1);zoom,0.5;halign,1;maxwidth,80),
+		SetCommand=function(self)
+			if score ~= nil then
+				if score:GetWifeScore() == 0 then 
+					self:settext("")
+				else
+					self:settext(skillsetsSSR[i]..":")
+				end
 			else
-				self:settextf("%5.2f", score:GetSkillsetSSR(3))
+				self:settext("")
 			end
-		else
-			self:settext("")
-		end
-	end,
-	ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
-}
+		end,
+		ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
+	}
 
-t[#t+1] = LoadFont("Common Normal")..{
-	Name="Score",
-	InitCommand=cmd(xy,frameX+offsetX+155,frameY+offsetY+48;zoom,0.5;halign,0),
-	SetCommand=function(self)
-		if score ~= nil then
-			if score:GetWifeScore() == 0 then 
-				self:settext("")
+	t[#t+1] = LoadFont("Common Normal")..{
+		Name="Score",
+		InitCommand=cmd(xy,frameX+frameWidth*0.7+2,frameY+offsetY+125+18*(i-1);zoom,0.5;halign,0;maxwidth,80),
+		SetCommand=function(self)
+			if score ~= nil then
+				if score:GetWifeScore() == 0 then 
+					self:settext("")
+				else
+					self:settextf("%5.2f", score:GetSkillsetSSR(i))
+					self:diffuse(ByMSD(score:GetSkillsetSSR(i)))
+				end
 			else
-				self:settextf("%5.2f", score:GetSkillsetSSR(4))
-			end
-		else
-			self:settext("")
-		end
-	end,
-	ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
-}
-
-t[#t+1] = LoadFont("Common Normal")..{
-	Name="Score",
-	InitCommand=cmd(xy,frameX+offsetX+155,frameY+offsetY+58;zoom,0.5;halign,0),
-	SetCommand=function(self)
-		if score ~= nil then
-			if score:GetWifeScore() == 0 then 
 				self:settext("")
-			else
-				self:settextf("%5.2f", score:GetSkillsetSSR(5))
 			end
-		else
-			self:settext("")
-		end
-	end,
-	ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
-}
+		end,
+		ScoreUpdateMessageCommand=cmd(queuecommand,"Set")
+	}
+end
 
 t[#t+1] = LoadFont("Common Normal")..{
 	Name="ClearType",

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -278,6 +278,23 @@ t[#t+1] = Def.ActorFrame{
 		CurrentRateChangedMessageCommand=cmd(queuecommand,"Set"),
 		RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
 	},
+
+	-- Score
+	LoadFont("Common Large")..{
+		InitCommand=cmd(xy,frameX+capWideScale(get43size(384),384)-5,270;zoom,0.7;halign,1),
+		BeginCommand=cmd(queuecommand,"Set"),
+		SetCommand=function(self)
+			if song and score then
+				local ssr = score:GetSkillsetSSR(1)
+				self:settextf("%00.2f", ssr)
+				self:diffuse(ByMSD(ssr))
+			else
+				self:settext("")
+			end
+		end,
+		CurrentRateChangedMessageCommand=cmd(queuecommand,"Set"),
+		RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
+	},
 	-- **End score related stuff**
 }
 
@@ -316,6 +333,18 @@ for i=1,5 do
 end
 
 -- Difficulty value ("meter"), need to change this later
+t[#t+1] = LoadFont("Common Normal") .. {
+	InitCommand=cmd(xy,frameX+2,DBLframeY+15;halign,0;maxwidth,80;zoom,0.4;diffusealpha,0.3),
+	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
+	SetCommand = function(self)
+		if song then
+			self:settext("RATING")
+		else
+			self:settext("")
+		end
+	end,
+}
+
 t[#t+1] = LoadFont("Common Large") .. {
 	InitCommand=cmd(xy,frameX+DBLCellWidth-4,DBLframeY+14;halign,1;zoom,0.45;maxwidth,(DBLCellWidth-4)/0.45),
 	BeginCommand=cmd(queuecommand,"Set"),
@@ -332,7 +361,20 @@ t[#t+1] = LoadFont("Common Large") .. {
 	CurrentRateChangedMessageCommand=cmd(queuecommand,"Set"),
 }
 
+
 -- Song duration
+t[#t+1] = LoadFont("Common Normal") .. {
+	InitCommand=cmd(xy,frameX+2+2*(DBLCellWidth+2),DBLframeY+15;halign,0;maxwidth,80;zoom,0.4;diffusealpha,0.3),
+	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
+	SetCommand = function(self)
+		if song then
+			self:settext("DURATION")
+		else
+			self:settext("")
+		end
+	end,
+}
+
 t[#t+1] = LoadFont("Common Large") .. {
 	InitCommand=cmd(xy,frameX+3*(DBLCellWidth+2)-4,DBLframeY+14;visible,true;halign,1;zoom,0.45;maxwidth,(DBLCellWidth-4)/0.45),
 	BeginCommand=cmd(queuecommand,"Set"),

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -1,6 +1,9 @@
 local profile = PROFILEMAN:GetProfile(PLAYER_1)
 local frameX = 10
 local frameY = 250+capWideScale(get43size(120),90)
+local DBLframeX = frameX
+local DBLframeY = 61+capWideScale(get43size(120),120)+5
+local DBLCellWidth = capWideScale(get43size(384),384)/3-2
 local frameWidth = capWideScale(get43size(455),455)
 local scoreType = themeConfig:get_data().global.DefaultScoreType
 local score
@@ -112,16 +115,26 @@ t[#t+1] = Def.Actor{
 	end,
 }
 
+-- Frames for calc, BPM and len
+t[#t+1] = Def.ActorFrame{
+	InitCommand=cmd(xy,DBLframeX,DBLframeY;halign,0;valign,0);
+	Def.Quad{InitCommand=cmd(xy,0*(DBLCellWidth+2)-1,0;zoomto,DBLCellWidth,30;halign,0;valign,0;diffuse,color("#333333EE");diffusealpha,0.66)},
+	Def.Quad{InitCommand=cmd(xy,1*(DBLCellWidth+2),0;zoomto,DBLCellWidth,30;halign,0;valign,0;diffuse,color("#333333EE");diffusealpha,0.66)},		
+	Def.Quad{InitCommand=cmd(xy,2*(DBLCellWidth+2)+1,0;zoomto,DBLCellWidth,30;halign,-0;valign,0;diffuse,color("#333333EE");diffusealpha,0.66)},		
+}
+
 t[#t+1] = Def.ActorFrame{
 	-- **frames/bars**
-	Def.Quad{InitCommand=cmd(xy,frameX,frameY-76;zoomto,110,94;halign,0;valign,0;diffuse,color("#333333CC");diffusealpha,0.66)},			--Upper Bar
-	Def.Quad{InitCommand=cmd(xy,frameX,frameY+18;zoomto,frameWidth+4,50;halign,0;valign,0;diffuse,color("#333333CC");diffusealpha,0.66)},	--Lower Bar
-	Def.Quad{InitCommand=cmd(xy,frameX,frameY-76;zoomto,8,144;halign,0;valign,0;diffuse,getMainColor('highlight');diffusealpha,0.5)},		--Side Bar (purple streak on the left)
+	Def.Quad{InitCommand=cmd(xy,frameX,220;zoomto,capWideScale(get43size(384),384),80;halign,0;valign,0;diffuse,color("#333333CC");diffusealpha,0.66)},		--Upper Bar
+	Def.Quad{InitCommand=cmd(xy,frameX,305;zoomto,capWideScale(get43size(384),384),100;halign,0;valign,0;diffuse,color("#333333CC");diffusealpha,0.66)},	--Lower Bar
+	Def.Quad{InitCommand=cmd(xy,frameX,305;zoomto,8,100;halign,0;valign,0;diffuse,getMainColor('highlight');diffusealpha,0.5)},		--Side Bar Lower (purple streak on the left)
+	Def.Quad{InitCommand=cmd(xy,frameX,220;zoomto,8,80;halign,0;valign,0;diffuse,getMainColor('highlight');diffusealpha,0.5)},		--Side Bar Upper (purple streak on the left)
 	
+	--Diff Bar
 	-- **score related stuff** These need to be updated with rate changed commands
 	-- Primary percent score
 	LoadFont("Common Large")..{
-		InitCommand=cmd(xy,frameX+55,frameY+50;zoom,0.6;halign,0.5;maxwidth,125;valign,1),
+		InitCommand=cmd(xy,frameX+15,248;zoom,0.6;halign,0;valign,1;maxwidth,170),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -142,7 +155,7 @@ t[#t+1] = Def.ActorFrame{
 	
 	-- Primary ScoreType
 	LoadFont("Common Large")..{
-		InitCommand=cmd(xy,frameX+125,frameY+40;zoom,0.3;halign,1;valign,1),
+		InitCommand=cmd(xy,frameX+120,248;zoom,0.3;halign,0;valign,1),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -160,8 +173,8 @@ t[#t+1] = Def.ActorFrame{
 	},
 	
 	-- Secondary percent score
-	LoadFont("Common Normal")..{
-		InitCommand=cmd(xy,frameX+130,frameY+63;zoom,0.6;halign,0.5;maxwidth,125;valign,1),
+	LoadFont("Common Large")..{
+		InitCommand=cmd(xy,frameX+15,278;zoom,0.6;halign,0;valign,1;maxwidth,170),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -181,8 +194,8 @@ t[#t+1] = Def.ActorFrame{
 	},
 	
 	-- Secondary ScoreType
-	LoadFont("Common Normal")..{
-		InitCommand=cmd(xy,frameX+173,frameY+63;zoom,0.4;halign,1;valign,1),
+	LoadFont("Common Large")..{
+		InitCommand=cmd(xy,frameX+120,278;zoom,0.3;halign,0;valign,1),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -200,8 +213,8 @@ t[#t+1] = Def.ActorFrame{
 	},
 	
 	-- Rate for the displayed score
-	LoadFont("Common Normal")..{
-		InitCommand=cmd(xy,frameX+55,frameY+58;zoom,0.5;halign,0.5),
+	LoadFont("Common Large")..{
+		InitCommand=cmd(xy,frameX+60,288;zoom,0.3;halign,0.5),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then 
@@ -238,7 +251,7 @@ t[#t+1] = Def.ActorFrame{
 	
 	-- Date score achieved on
 	LoadFont("Common Normal")..{
-		InitCommand=cmd(xy,frameX+185,frameY+59;zoom,0.4;halign,0),
+		InitCommand=cmd(xy,frameX+capWideScale(get43size(384),384)-5,230;zoom,0.5;halign,1),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -253,7 +266,7 @@ t[#t+1] = Def.ActorFrame{
 
 	-- MaxCombo
 	LoadFont("Common Normal")..{
-		InitCommand=cmd(xy,frameX+185,frameY+49;zoom,0.4;halign,0),
+		InitCommand=cmd(xy,frameX+capWideScale(get43size(384),384)-5,245;zoom,0.5;halign,1),
 		BeginCommand=cmd(queuecommand,"Set"),
 		SetCommand=function(self)
 			if song and score then
@@ -272,7 +285,7 @@ t[#t+1] = Def.ActorFrame{
 local function radarPairs(i)
 	local o = Def.ActorFrame{
 		LoadFont("Common Normal")..{
-			InitCommand=cmd(xy,frameX+13,frameY-52+13*i;zoom,0.5;halign,0;maxwidth,120),
+			InitCommand=cmd(xy,frameX+13,frameY-42+19*i;zoom,0.5;halign,0;maxwidth,120),
 			SetCommand=function(self)
 				if song then
 					self:settext(ms.RelevantRadarsShort[i])
@@ -283,7 +296,7 @@ local function radarPairs(i)
 			RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
 		},
 		LoadFont("Common Normal")..{
-			InitCommand=cmd(xy,frameX+105,frameY+-52+13*i;zoom,0.5;halign,1;maxwidth,60),
+			InitCommand=cmd(xy,frameX+115,frameY+-42+19*i;zoom,0.5;halign,1;maxwidth,90),
 			SetCommand=function(self)
 				if song then		
 					self:settext(steps:GetRelevantRadars(PLAYER_1)[i])
@@ -304,12 +317,12 @@ end
 
 -- Difficulty value ("meter"), need to change this later
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,frameX+58,frameY-62;halign,0.5;zoom,0.6;maxwidth,110/0.6),
+	InitCommand=cmd(xy,frameX+DBLCellWidth-4,DBLframeY+14;halign,1;zoom,0.45;maxwidth,(DBLCellWidth-4)/0.45),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if song then
 			local meter = steps:GetMSD(getCurRateValue(), 1)
-			self:settextf("%05.2f",meter)
+			self:settextf("%5.2f",meter)
 			self:diffuse(ByMSD(meter))
 		else
 			self:settext("")
@@ -321,7 +334,7 @@ t[#t+1] = LoadFont("Common Large") .. {
 
 -- Song duration
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,(capWideScale(get43size(384),384))+62,SCREEN_BOTTOM-85;visible,true;halign,1;zoom,capWideScale(get43size(0.6),0.6);maxwidth,capWideScale(get43size(360),360)/capWideScale(get43size(0.45),0.45)),
+	InitCommand=cmd(xy,frameX+3*(DBLCellWidth+2)-4,DBLframeY+14;visible,true;halign,1;zoom,0.45;maxwidth,(DBLCellWidth-4)/0.45),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if song then
@@ -337,10 +350,22 @@ t[#t+1] = LoadFont("Common Large") .. {
 }
 
 -- BPM display/label not sure why this was never with the chart info in the first place
+t[#t+1] = LoadFont("Common Normal") .. {
+	SetCommand = function(self)
+		if song then
+			self:settext("BPM")
+		else
+			self:settext("")
+		end
+	end,
+	InitCommand=cmd(xy,frameX+2+1*(DBLCellWidth+2),DBLframeY+9;halign,0;zoom,0.4;diffusealpha,0.3),
+	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
+}
+
 t[#t+1] = Def.BPMDisplay {
 	File=THEME:GetPathF("BPMDisplay", "bpm"),
 	Name="BPMDisplay",
-	InitCommand=cmd(xy,capWideScale(get43size(384),384)+62,SCREEN_BOTTOM-100;halign,1;zoom,0.50),
+	InitCommand=cmd(xy,frameX+2*(DBLCellWidth+2)-4,DBLframeY+14;halign,1;zoom,0.45;maxwidth,(DBLCellWidth-4)/0.45),
 	SetCommand=function(self)
 		if song then 
 			self:visible(1)
@@ -353,22 +378,9 @@ t[#t+1] = Def.BPMDisplay {
 	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
 }
 
-t[#t+1] = LoadFont("Common Normal") .. {
-	SetCommand = function(self)
-		if song then
-			self:settext("BPM")
-		else
-			self:settext("")
-		end
-	end,
-	InitCommand=cmd(xy,capWideScale(get43size(384),384)+41,SCREEN_BOTTOM-100;halign,1;zoom,0.50),
-	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
-}
-
--- CDtitle, need to figure out a better place for this later. -mina
---Gonna move the cdtitle right next to selected song similar to ultralight. -Misterkister
+-- CDtitle, need to figure out a better place for this later
 t[#t+1] = Def.Sprite {
-	InitCommand=cmd(xy,capWideScale(get43size(344),364)+50,capWideScale(get43size(345),255);halign,0.5;valign,1),
+	InitCommand=cmd(xy,capWideScale(get43size(384),384)+50,capWideScale(get43size(210),180)+50;halign,0.5;valign,1),
 	SetCommand=function(self)
 		self:finishtweening()
 		if GAMESTATE:GetCurrentSong() then
@@ -408,7 +420,7 @@ t[#t+1] = Def.Sprite {
 }
 
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,frameX,frameY-120;halign,0;zoom,0.4),
+	InitCommand=cmd(xy,frameX+capWideScale(get43size(384),384)-10,320;halign,1;zoom,0.4),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if steps:GetTimingData():HasWarps() then
@@ -450,7 +462,7 @@ t[#t+1] = LoadFont("Common Large") .. {
 
 
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,frameX+120,frameY-60;halign,0;zoom,0.4,maxwidth,125),
+	InitCommand=cmd(xy,frameX+130,frameY-15;halign,0;zoom,0.4,maxwidth,125),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if song then
@@ -464,7 +476,7 @@ t[#t+1] = LoadFont("Common Large") .. {
 }
 
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,frameX+120,frameY-30;halign,0;zoom,0.4,maxwidth,125),
+	InitCommand=cmd(xy,frameX+130,frameY+15;halign,0;zoom,0.4,maxwidth,125),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if song then
@@ -478,7 +490,7 @@ t[#t+1] = LoadFont("Common Large") .. {
 }
 
 t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,frameX+120,frameY;halign,0;zoom,0.4,maxwidth,125),
+	InitCommand=cmd(xy,frameX+130,frameY+45;halign,0;zoom,0.4,maxwidth,125),
 	BeginCommand=cmd(queuecommand,"Set"),
 	SetCommand=function(self)
 		if song then

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -26,19 +26,6 @@ local t = Def.ActorFrame{
 	TabChangedMessageCommand=cmd(queuecommand,"Set"),
 }
 
--- Music Rate Display
-t[#t+1] = LoadFont("Common Large") .. {
-	InitCommand=cmd(xy,18,SCREEN_BOTTOM-225;visible,true;halign,0;zoom,0.4;maxwidth,capWideScale(get43size(360),360)/capWideScale(get43size(0.45),0.45)),
-	BeginCommand=function(self)
-		self:settext(getCurRateDisplayString())
-	end,
-	CodeMessageCommand=function(self,params)
-		local rate = getCurRateValue()
-		ChangeMusicRate(rate,params)
-		self:settext(getCurRateDisplayString())
-	end,
-}
-
 -- Temporary update control tower; it would be nice if the basic song/step change commands were thorough and explicit and non-redundant
 t[#t+1] = Def.Actor{
 	SetCommand=function(self)
@@ -515,6 +502,20 @@ t[#t+1] = LoadFont("Common Large") .. {
 	CurrentStepsP1ChangedMessageCommand=cmd(queuecommand,"Set"),
 	RefreshChartInfoMessageCommand=cmd(queuecommand,"Set"),
 }
+
+-- Music Rate Display
+t[#t+1] = LoadFont("Common Normal") .. {
+	InitCommand=cmd(xy,frameX+2+1*(DBLCellWidth+2),DBLframeY+20;halign,0;zoom,0.4;diffusealpha,0.3),
+	BeginCommand=function(self)
+		self:settext(getCurRateDisplayStringWifeTwirl())
+	end,
+	CodeMessageCommand=function(self,params)
+		local rate = getCurRateValue()
+		ChangeMusicRate(rate,params)
+		self:settext(getCurRateDisplayStringWifeTwirl())
+	end,
+}
+
 
 
 return t

--- a/Themes/Til Death/Fonts/BPMDisplay bpm.redir
+++ b/Themes/Til Death/Fonts/BPMDisplay bpm.redir
@@ -1,0 +1,1 @@
+Common Large

--- a/Themes/Til Death/Scripts/WifeSundries.lua
+++ b/Themes/Til Death/Scripts/WifeSundries.lua
@@ -173,7 +173,17 @@ function getCurRateDisplayString()
 	elseif o == "2x" then
 		o = "2.0x"
 	end
-	return o.."Music"
+	return o .. "Music"
+end
+
+function getCurRateDisplayStringWifeTwirl()
+	local o = getCurRateString()
+	if o == "1x" then
+		o = "1.0x"
+	elseif o == "2x" then
+		o = "2.0x"
+	end
+	return o
 end
 
 function getCurRateValue()


### PR DESCRIPTION
**General Tab:**
This is the part that needed most change, as a good chunk of the screen was left unused. This maximizes screen usage and makes play/step/chart data a bit tidier.
* Rearrange the screen in three sections: Rating/BPM/Length, Best play and Step data.
* Move rate next to BPM
* Add overall score of best play in the best play section
* Move "NegBpms!" down with step data
* Move CDTitle right below the difficulty list
_Notes:_
* Chord cohesion text placement may need to be moved as well
* Overall score may fall unneeded

**Score tab:**
* Add SSR breakdown in Score tab next to judgments

**Misc**
* Add a General tab-specific rate display (does not display the "Music" part)